### PR TITLE
Add multiple currency selection for ad submission

### DIFF
--- a/app/Controllers/Admin/Meta/SaveListingMetaData.php
+++ b/app/Controllers/Admin/Meta/SaveListingMetaData.php
@@ -222,6 +222,16 @@ class SaveListingMetaData {
 				$geo_address = isset( $_POST['rtcl_geo_address'] ) ? Functions::sanitize( $_POST['rtcl_geo_address'] ) : '';
 				update_post_meta( $post_id, '_rtcl_geo_address', $geo_address );
 			}
+
+			// Save listing currency
+			if ( isset( $_POST['_rtcl_listing_currency'] ) ) {
+				$listing_currency = Functions::sanitize( $_POST['_rtcl_listing_currency'] );
+				if ( ! empty( $listing_currency ) ) {
+					update_post_meta( $post_id, '_rtcl_listing_currency', $listing_currency );
+				} else {
+					delete_post_meta( $post_id, '_rtcl_listing_currency' );
+				}
+			}
 		}
 
 		do_action( 'rtcl_listing_update_metas_at_admin', $post_id, $_POST );

--- a/app/Controllers/Hooks/ActionHooks.php
+++ b/app/Controllers/Hooks/ActionHooks.php
@@ -22,6 +22,16 @@ class ActionHooks {
 		add_action( 'rtcl_listing_seller_contact_form_validation', [ __CLASS__, 'seller_form_validation' ], 10, 2 );
 		add_action( 'rtcl_listing_report_abuse_form_validation', [ __CLASS__, 'report_abuse_form_validation' ], 10, 2 );
 		add_action( 'rtcl_listing_report_abuse_form_validation', [ __CLASS__, 'report_abuse_form_validation' ], 10, 2 );
+		add_action( 'rtcl_listing_form_currency_select', [ __CLASS__, 'add_currency_select_field' ], 10, 1 );
+	}
+
+	/**
+	 * Adds the currency selection field to the listing form.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function add_currency_select_field( $post_id ) {
+		Functions::get_template( 'listing-form/currency-select', [ 'post_id' => $post_id ] );
 	}
 
 	/**

--- a/app/Controllers/Settings/AdminSettings.php
+++ b/app/Controllers/Settings/AdminSettings.php
@@ -483,6 +483,25 @@ class AdminSettings extends SettingsAPI {
 		if ( $this->current_section && 'tax_rate' === $this->current_section ) {
 			include RTCL_PATH . "views/settings/tax-rate-settings.php";
 		} else {
+			// Add new currency settings to the general tab
+			if ( 'general' === $this->active_tab && ! $this->current_section ) {
+				$currencies = \Rtcl\Resources\Options::get_currencies();
+				$field['enable_multiple_currencies'] = [
+					'title'   => esc_html__( 'Enable Multiple Currencies', 'classified-listing' ),
+					'type'    => 'checkbox',
+					'label'   => esc_html__( 'Allow users to select currency when submitting an ad', 'classified-listing' ),
+					'default' => 'no',
+				];
+				$field['available_currencies'] = [
+					'title'   => esc_html__( 'Available Currencies', 'classified-listing' ),
+					'type'    => 'multiselect',
+					'class'   => 'rtcl-select2',
+					'options' => $currencies,
+					'default' => [ Functions::get_currency() ],
+					'desc_tip' => esc_html__( 'Select the currencies available for users when submitting an ad.', 'classified-listing' ),
+					'dependency' => ['id' => 'rtcl_general_settings-enable_multiple_currencies', 'value' => 'yes', 'type' => 'visible'],
+				];
+			}
 			$this->form_fields = apply_filters( 'rtcl_settings_option_fields', $field, $this->active_tab, $this->current_section );
 		}
 	}

--- a/app/Resources/ListingDetails.php
+++ b/app/Resources/ListingDetails.php
@@ -171,7 +171,7 @@ class ListingDetails {
 									echo sprintf(
 										'<span class="price-label">%s [<span class="rtcl-currency-symbol">%s</span>]</span>',
 										esc_html__( 'Price', 'classified-listing' ),
-										esc_html( apply_filters( 'rtcl_listing_price_currency_symbol', Functions::get_currency_symbol(), $listing ) )
+										esc_html( apply_filters( 'rtcl_listing_price_currency_symbol', Functions::get_currency_symbol( Functions::get_listing_currency( $listing->get_id() ) ), $listing ) )
 									);
 									?>
 									<span
@@ -189,7 +189,7 @@ class ListingDetails {
 									echo sprintf(
 										'<span class="price-label">%s [<span class="rtcl-currency-symbol">%s</span>]</span>',
 										esc_html__( 'Max Price', 'classified-listing' ),
-										esc_html( apply_filters( 'rtcl_listing_price_currency_symbol', Functions::get_currency_symbol(), $listing ) )
+										esc_html( apply_filters( 'rtcl_listing_price_currency_symbol', Functions::get_currency_symbol( Functions::get_listing_currency( $listing->get_id() ) ), $listing ) )
 									);
 									?>
 									<span

--- a/templates/listing-form/currency-select.php
+++ b/templates/listing-form/currency-select.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Listing Currency Selection Field
+ *
+ * @author     RadiusTheme
+ * @package    classified-listing/templates
+ * @version    1.0.0
+ *
+ * @var int $post_id
+ */
+
+use Rtcl\Helpers\Functions;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( Functions::get_option_item( 'rtcl_general_settings', 'enable_multiple_currencies', 'no' ) !== 'yes' ) {
+	return;
+}
+
+$available_currencies = Functions::get_available_currencies();
+// If only one or no currency is available (e.g. main currency only), don't show the dropdown.
+if ( count( $available_currencies ) <= 1 ) {
+	return;
+}
+
+$current_currency = $post_id ? Functions::get_listing_currency( $post_id ) : Functions::get_currency();
+?>
+<div class="rtcl-form-group rtcl-listing-currency-wrap">
+	<label for="rtcl-listing-currency"><?php esc_html_e( 'Currency', 'classified-listing' ); ?></label>
+	<select class="rtcl-form-control rtcl-select2" id="rtcl-listing-currency" name="_rtcl_listing_currency">
+		<?php
+		foreach ( $available_currencies as $currency_code => $currency_name ) {
+			printf(
+				'<option value="%s"%s>%s</option>',
+				esc_attr( $currency_code ),
+				selected( $current_currency, $currency_code, false ),
+				esc_html( $currency_name )
+			);
+		}
+		?>
+	</select>
+</div>

--- a/templates/listing-form/form.php
+++ b/templates/listing-form/form.php
@@ -15,6 +15,7 @@
 	<?php do_action("rtcl_listing_form_before", $post_id); ?>
 	<form action="" method="post" id="rtcl-post-form" class="form-vertical">
 		<?php do_action("rtcl_listing_form_start", $post_id); ?>
+		<?php do_action("rtcl_listing_form_currency_select", $post_id); ?>
 		<div class="rtcl-post">
 			<?php do_action("rtcl_listing_form", $post_id); ?>
 		</div>

--- a/templates/listing-form/information.php
+++ b/templates/listing-form/information.php
@@ -106,7 +106,7 @@ use Rtcl\Resources\Options;
 								class="rtcl-field-label"><?php echo sprintf( '<span class="price-label">%s [<span class="rtcl-currency-symbol">%s</span>]</span>',
 									esc_html__( "Price", 'classified-listing' ),
 									// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-									apply_filters( 'rtcl_listing_price_currency_symbol', Functions::get_currency_symbol(), $listing )
+									apply_filters( 'rtcl_listing_price_currency_symbol', Functions::get_currency_symbol( $listing ? Functions::get_listing_currency( $listing->get_id() ) : Functions::get_currency() ), $listing )
 								); ?>
 								<span
 									class="require-star">*</span></label>
@@ -121,7 +121,7 @@ use Rtcl\Resources\Options;
 								for="rtcl-max-price" class="rtcl-field-label"><?php echo sprintf( '<span class="price-label">%s [<span class="rtcl-currency-symbol">%s</span>]</span>',
 									esc_html__( "Max Price", 'classified-listing' ),
 									// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-									apply_filters( 'rtcl_listing_price_currency_symbol', Functions::get_currency_symbol(), $listing )
+									apply_filters( 'rtcl_listing_price_currency_symbol', Functions::get_currency_symbol( $listing ? Functions::get_listing_currency( $listing->get_id() ) : Functions::get_currency() ), $listing )
 								); ?><span
 									class="require-star">*</span></label>
 							<input type="text"


### PR DESCRIPTION
This commit introduces the ability for users to select a currency when creating or editing an ad, if enabled in the plugin settings.

Key changes:
- Added settings in the General tab to enable multiple currencies and select available currencies.
- Updated helper functions to handle currency-specific formatting and retrieval.
- Added a currency selection dropdown to the listing submission form.
- Ensured the selected currency symbol is displayed correctly on the form and listing views.
- Implemented saving the selected currency with the listing data.